### PR TITLE
Add `end_page` arg to Pro API Paginator

### DIFF
--- a/src/jamf_pro_sdk/__about__.py
+++ b/src/jamf_pro_sdk/__about__.py
@@ -1,2 +1,2 @@
 __title__ = "jamf-pro-sdk"
-__version__ = "0.2a1"
+__version__ = "0.2a2"

--- a/src/jamf_pro_sdk/clients/pro_api/__init__.py
+++ b/src/jamf_pro_sdk/clients/pro_api/__init__.py
@@ -29,6 +29,7 @@ class ProApi:
         self,
         sections: List[str] = None,
         start_page: int = 0,
+        end_page: int = None,
         page_size: int = 100,
         sort_expression: SortExpression = None,
         filter_expression: FilterExpression = None,
@@ -43,6 +44,10 @@ class ProApi:
 
         :param start_page: (optional) The page to begin returning results from. See
             :class:`Paginator` for more information.
+        :type start_page: int
+
+        :param end_page: (optional) The page to end returning results at. See :class:`Paginator` for
+            more information.
         :type start_page: int
 
         :param page_size: (optional) The number of results to include in each requested page. See
@@ -192,6 +197,7 @@ class ProApi:
             resource_path="v1/computers-inventory",
             return_model=Computer,
             start_page=start_page,
+            end_page=end_page,
             page_size=page_size,
             sort_expression=sort_expression,
             filter_expression=filter_expression,

--- a/src/jamf_pro_sdk/clients/pro_api/pagination.py
+++ b/src/jamf_pro_sdk/clients/pro_api/pagination.py
@@ -162,6 +162,12 @@ class Paginator:
 
         :param start_page: (optional) The page to begin returning results from. Generally this value
             should be left at the default (``0``).
+
+            .. note::
+
+                Pages in the Pro API are zero-indexed. In a response that includes 10 pages the first
+                page is ``0`` and the last page is ``9``.
+
         :type start_page: int
 
         :param end_page: (optional) The page number to stop pagination on. The ``end_page`` argument

--- a/src/jamf_pro_sdk/clients/pro_api/pagination.py
+++ b/src/jamf_pro_sdk/clients/pro_api/pagination.py
@@ -139,6 +139,7 @@ class Paginator:
         resource_path: str,
         return_model: Type[BaseModel] = None,
         start_page: int = 0,
+        end_page: int = None,
         page_size: int = 100,
         sort_expression: SortExpression = None,
         filter_expression: FilterExpression = None,
@@ -163,6 +164,11 @@ class Paginator:
             should be left at the default (``0``).
         :type start_page: int
 
+        :param end_page: (optional) The page number to stop pagination on. The ``end_page`` argument
+            allows for retrieving page ranges (e.g. 2 - 4) or a single page result by using the same
+            number for both start and end values.
+        :type start_page: int
+
         :param page_size: (optional) The number of results to include in each requested page. The
             default value is ``100`` and the maximum value is ``2000``.
         :type page_size: int
@@ -184,6 +190,7 @@ class Paginator:
         self.resource_path = resource_path
         self.return_model = return_model
         self.start_page = start_page
+        self.end_page = end_page
         self.page_size = page_size
         self.sort_expression = sort_expression
         self.filter_expression = filter_expression
@@ -215,13 +222,19 @@ class Paginator:
         first_page = self._paginated_request(page=self.start_page)
         yield first_page
 
-        if (total_count := first_page.total_count) > (results_count := len(first_page.results)):
+        total_count = (
+            min(first_page.total_count, (self.end_page * self.page_size))
+            if self.end_page
+            else first_page.total_count
+        )
+
+        if total_count > (results_count := len(first_page.results)):
             for page in self._api_client.concurrent_api_requests(
                 self._paginated_request,
                 [
                     {"page": i}
                     for i in range(
-                        self.start_page + 1,
+                        self.start_page,
                         math.ceil((total_count - results_count) / self.page_size) + 1,
                     )
                 ],

--- a/src/jamf_pro_sdk/clients/pro_api/pagination.py
+++ b/src/jamf_pro_sdk/clients/pro_api/pagination.py
@@ -223,7 +223,7 @@ class Paginator:
         yield first_page
 
         total_count = (
-            min(first_page.total_count, (self.end_page * self.page_size))
+            min(first_page.total_count, (self.end_page + 1) * self.page_size)
             if self.end_page
             else first_page.total_count
         )


### PR DESCRIPTION
This adds an optional `end_page` argument to the Pro API `Paginator` allowing for limiting pages returned, or selecting a range of pages in an operation.

This example has a full result of 10 pages (0-9). This paginator will skip pages 0-3, return pages 4-7, and stop.

```python
paginator = Paginator(
    api_client=client.pro_api,
    resource_path="v1/computers-inventory",
    page_size=100,
    start_page=4,
    end_page=7
)
```