### PR TITLE
Update criteria.py

### DIFF
--- a/src/jamf_pro_sdk/models/classic/criteria.py
+++ b/src/jamf_pro_sdk/models/classic/criteria.py
@@ -33,6 +33,7 @@ class ClassicCriterionSearchType(str, Enum):
     current: str = "current"
     not_current: str = "not current"
     greater_than: str = "greater than"
+    more_than: str = "more than"
     less_than: str = "less than"
     greater_than_or_equal: str = "greater than or equal"
     less_than_or_equal: str = "less than or equal"

--- a/src/jamf_pro_sdk/models/classic/criteria.py
+++ b/src/jamf_pro_sdk/models/classic/criteria.py
@@ -32,6 +32,8 @@ class ClassicCriterionSearchType(str, Enum):
     less_than_x_days_ago: str = "less than x days ago"
     current: str = "current"
     not_current: str = "not current"
+    member_of: str = "member of"
+    not_member_of: str = "not member of"
     greater_than: str = "greater than"
     more_than: str = "more than"
     less_than: str = "less than"


### PR DESCRIPTION
I was pulling smart groups and got a Pydantic validation error on a smart group that had a "more than" comparison operator on a numeric (drive full percentage, in my case). Should we add that operator? It seemed to resolve the issue without making any other changes. 

Also, thanks for this SDK. I'm still having lots of "Ooh... I see what you did there..." moments. 

<img width="743" alt="image" src="https://github.com/macadmins/jamf-pro-sdk-python/assets/25835285/5e076b84-339f-429e-8e86-7bf82ddd3e8b">
