### PR TITLE
Returned paginator object includes extra params

### DIFF
--- a/src/jamf_pro_sdk/clients/pro_api/__init__.py
+++ b/src/jamf_pro_sdk/clients/pro_api/__init__.py
@@ -418,6 +418,7 @@ class ProApi:
             page_size=page_size,
             sort_expression=sort_expression,
             filter_expression=filter_expression,
+            extra_params={"section": ",".join(sections)},
         )
 
         return paginator(return_generator=return_generator)


### PR DESCRIPTION
Fixes #44 originally [reported by mbootes](https://macadmins.slack.com/archives/C0EP2SNJX/p1720160121029229) on the Mac Admins slack. 