### PR TITLE
Fix missing criteria search types

### DIFF
--- a/src/jamf_pro_sdk/models/classic/criteria.py
+++ b/src/jamf_pro_sdk/models/classic/criteria.py
@@ -34,8 +34,9 @@ class ClassicCriterionSearchType(str, Enum):
     not_current: str = "not current"
     member_of: str = "member of"
     not_member_of: str = "not member of"
-    greater_than: str = "greater than"
+    more_than: str = "more than"
     less_than: str = "less than"
+    greater_than: str = "greater than"
     greater_than_or_equal: str = "greater than or equal"
     less_than_or_equal: str = "less than or equal"
 

--- a/src/jamf_pro_sdk/models/classic/criteria.py
+++ b/src/jamf_pro_sdk/models/classic/criteria.py
@@ -32,6 +32,8 @@ class ClassicCriterionSearchType(str, Enum):
     less_than_x_days_ago: str = "less than x days ago"
     current: str = "current"
     not_current: str = "not current"
+    member_of: str = "member of"
+    not_member_of: str = "not member of"
     greater_than: str = "greater than"
     less_than: str = "less than"
     greater_than_or_equal: str = "greater than or equal"


### PR DESCRIPTION
Add the following search types to the criteria object:
- member of
- not member of

Fixes #41 