### PR TITLE
Fix malformed XML when model contains enums

### DIFF
--- a/src/jamf_pro_sdk/models/classic/criteria.py
+++ b/src/jamf_pro_sdk/models/classic/criteria.py
@@ -44,7 +44,7 @@ class ClassicCriterionSearchType(str, Enum):
 class ClassicCriterion(BaseModel):
     """Classic API criterion. Used by Smart Groups and Advanced Searches."""
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="allow", use_enum_values=True)
 
     name: str
     priority: int


### PR DESCRIPTION
Configure Pydantic model to use enum values when performing a dump.

Fixes #46 