### PR TITLE
Remove `black` and standardize on `ruff` for linting and formatting.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,11 @@ test-all:
 	pytest tests
 
 lint:
-	black --check src tests
+	ruff format --check src tests
 	ruff check src tests
 
 format:
-	black src tests # You can have it any color you want...
+	ruff format src tests
 	ruff check --select I001 --fix src tests # Only fixes import order
 
 build:

--- a/docs/contributors/index.rst
+++ b/docs/contributors/index.rst
@@ -29,7 +29,7 @@ Before writing code and opening a pull request to add to the project, please ope
 Code contributors are required to uphold project standards:
 
 * Consistency with existing SDK interfaces.
-* All code conforms to formatting and styling (``black`` and ``ruff`` are used in this project, and are enforced at pull request).
+* All code conforms to formatting and styling (``ruff`` is used in this project and is enforced at pull request).
 * All changes are documented in the users guides, references, and docstrings.
 * Code changes are covered by additional tests (future: this project will not have a full test suite until it comes out of alpha).
 * Backwards compatibility is not broken by the contributions (with the exception of the alpha period where breaking changes may be allowed on a case-by-case basis).
@@ -61,7 +61,7 @@ There are two additional ``make`` commands for maintaining your local environmen
 Code Quality
 ^^^^^^^^^^^^
 
-The ``black`` and ``ruff`` tools will enforce formatting standards for the codebase. The settings for these tools are defined in `pyproject.toml <https://github.com/macadmins/jamf-pro-sdk-python/blob/main/pyproject.toml>`_.
+The ``ruff`` tool will enforce formatting standards for the codebase. The settings are defined in `pyproject.toml <https://github.com/macadmins/jamf-pro-sdk-python/blob/main/pyproject.toml>`_.
 
 * ``make lint`` will check if your code is compliant with the formatting and linting rules without making changes.
 * ``make format`` will edit your code to comply with the formatting and linting rules.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 
 
@@ -43,7 +44,6 @@ dev = [
     "boto3>=1.26.45,<2",
     "keyring>=23.13.1",
     "polyfactory>=2.1.1,<3",
-    "black[d]",
     "ruff",
     "coverage[toml]",
     "pytest >= 6",
@@ -77,10 +77,6 @@ version = {attr = "jamf_pro_sdk.__about__.__version__"}
 readme = {file = ["README.md"], content-type = "text/markdown"}
 
 
-[tool.black]
-line-length = 100
-
-
 [tool.ruff]
 line-length = 100
 target-version = "py39"
@@ -89,6 +85,13 @@ src = [
     "tests"
 ]
 
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
+docstring-code-format = false
+docstring-code-line-length = "dynamic"
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
One less tool.