### PR TITLE
Minor documentation updates

### DIFF
--- a/docs/contributors/index.rst
+++ b/docs/contributors/index.rst
@@ -47,9 +47,9 @@ It is recommended you use a Python virtual environment for local development (se
 
 With your virtual environment active run the following from the SDK repository's directory:
 
-.. code-block:: shell
+.. code-block:: console
 
-    (.vent) % make install
+    (.venv) % make install
 
 This will install the package in editable mode with all dev and optional dependencies.
 

--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -37,6 +37,11 @@ Import the Jamf Pro client from the SDK:
 
 Create a client object passing in your Jamf Pro server name and a username and password:
 
+.. note::
+
+    When passing your Jamf Pro server name, do not include the scheme (``https://``) as the SDK handles this automatically for you.
+
+
     >>> client = JamfProClient(
     ...     server="jamf.my.org",
     ...     credentials=BasicAuthProvider("oscar", "j@mf1234!")


### PR DESCRIPTION
### Changes the following: 
- Fixes a typo in contributors/index.rst `(.vent) → (.venv)`
- Changes code block directive to use console instead of shell. This was for syntax highlighting purposes, and to remain consistent throughout the documentation as this was the only instance of a shell code block. 
- Adds a note to user guide about omitting URL scheme when instantiating a `JamfClient` object. SDK automatically handles this, if users add this information, the following error would be thrown: 

```
requests.exceptions.ConnectionError: HTTPSConnectionPool(host='https', port=443): Max retries exceeded with url: /<sanitized>:443/api/v1/auth/token (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection object at 0x104572ec0>: Failed to resolve 'https' ([Errno 8] nodename nor servname provided, or not known)"))
```
