### PR TITLE
Update action versions, pin to commit hashes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Dependabot
+.github/workflows/* @nstrauss @liquidz00

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/main_pr_tests.yaml
+++ b/.github/workflows/main_pr_tests.yaml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.9'
           cache: 'pip'

--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -7,6 +7,10 @@ on:
     paths:
       - 'docs/**'
       - 'src/**'
+    workflow_dispatch:
+      inputs:
+        ref:
+          description: The branch, tag, or commit SHA1 to build the docs from.
 
 permissions:
   contents: read
@@ -26,10 +30,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.9'
 
@@ -39,10 +45,10 @@ jobs:
           make docs
 
       - name: Upload Artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: 'build/docs/'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/publish_pypi.yaml
+++ b/.github/workflows/publish_pypi.yaml
@@ -17,12 +17,12 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.ref }}
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.9'
 
@@ -33,4 +33,4 @@ jobs:
         run: make build
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4


### PR DESCRIPTION
https://github.com/macadmins/jamf-pro-sdk-python/actions/runs/15101803299
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Publishing docs from https://github.com/macadmins/jamf-pro-sdk-python/pull/60 since the workflow was using an old version of `upload-pages-artifact` which referenced a deprecated version of `upload-artifact`.  Let's try to do a better job of keeping actions up to date and working in the future.

```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```

- Bump all action versions to latest.
- Pin versions to commit hashes. This is a practice I've followed pretty much the entire time I've used GitHub Actions. Slightly more piece of mind, and not much more maintenance with Dependabot. https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions
- Add [Dependabot](https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide) with monthly along with CODEOWNERS to auto-assign PRs to myself and @liquidz00.
- Support publishing docs from a manual run with `workflow_dispatch`. Once this PR is merged I'll use it to retry the failed run linked above.