### PR TITLE
Fixup workflow_dispatch for docs publishing

### DIFF
--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -7,10 +7,10 @@ on:
     paths:
       - 'docs/**'
       - 'src/**'
-    workflow_dispatch:
-      inputs:
-        ref:
-          description: The branch, tag, or commit SHA1 to build the docs from.
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: The branch, tag, or commit SHA1 to build the docs from.
 
 permissions:
   contents: read


### PR DESCRIPTION
Follow up from https://github.com/macadmins/jamf-pro-sdk-python/pull/62 Bad indentation causing `workflow_dispatch` not to work. 