### PR TITLE
Added lastInventoryUpdateDate filter field for mobile inventory api

### DIFF
--- a/src/jamf_pro_sdk/models/pro/api_options.py
+++ b/src/jamf_pro_sdk/models/pro/api_options.py
@@ -394,6 +394,7 @@ get_mobile_device_inventory_v2_allowed_filter_fields = [
     "itunesStoreAccountActive",
     "mobileDeviceId",
     "languages",
+    "lastInventoryUpdateDate",
     "locales",
     "locationServicesForSelfServiceMobileEnabled",
     "lostModeEnabled",


### PR DESCRIPTION
lastInventoryUpdateDate field is supported as filter in the https://developer.jamf.com/jamf-pro/reference/get_v2-mobile-devices-detail API. 